### PR TITLE
CI: Enable test runs on renovate branches

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,24 +5,26 @@ on:
   workflow_dispatch:
   workflow_call:
   push:
-    branches: [main]
+    branches: ["main", "renovate/*"]
     paths:
       - "go.mod"
       - "go.sum"
       - "*.go"
       - ".golangci.yml"
   pull_request:
-    branches: [main]
+    branches: ["main"]
   merge_group:
-    branches: [main]
+    branches: ["main"]
 
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
-      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+      - name: Setup Golang
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version: 'stable'
           cache-dependency-path: go.sum
@@ -36,11 +38,12 @@ jobs:
 
   unit-tests:
     runs-on: ubuntu-latest
-    needs: lint
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
-      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+      - name: Setup Golang
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version: 'stable'
           cache-dependency-path: go.sum

--- a/.github/workflows/editorconfig-check.yaml
+++ b/.github/workflows/editorconfig-check.yaml
@@ -3,6 +3,8 @@ name: "Editorconfig Check"
 
 on:
   workflow_dispatch:
+  push:
+    branches: ["main", "renovate/*"]
   pull_request:
     branches: ["main"]
   merge_group:

--- a/.github/workflows/go-testcover-report.yaml
+++ b/.github/workflows/go-testcover-report.yaml
@@ -26,7 +26,8 @@ jobs:
           ref: "main"
           path: "main"
 
-      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+      - name: Setup Golang
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version: 'stable'
           cache-dependency-path: go.sum

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
-      - uses: ncipollo/release-action@6c75be85e571768fa31b40abf38de58ba0397db5 # v1.13.0
+      - name: Create release
+        uses: ncipollo/release-action@6c75be85e571768fa31b40abf38de58ba0397db5 # v1.13.0
         with:
           allowUpdates: ${{ inputs.update }}
           artifactErrorsFailBuild: true


### PR DESCRIPTION
Speed up CI by running unit-tests and lint in parallel.
Add names to workflow steps.