### PR TITLE
CI: Do not run on push to renovate branches

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ name: CI
 on:
   workflow_dispatch:
   push:
-    branches: ["main", "renovate/*"]
+    branches: ["main"]
     paths:
       - "go.mod"
       - "go.sum"


### PR DESCRIPTION
All commits should be done through PRs, so there is no need to run on pushes to renovate branches.