### PR TITLE
go.mod: Update go to version 1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/heathcliff26/promremote
 
-go 1.21.0
-
-toolchain go1.23.0
+go 1.22
 
 require (
 	github.com/golang/snappy v0.0.4


### PR DESCRIPTION
Since some of the dependencies use toolchains, it should be at least go 1.22.