### PR TITLE
go.mod: Update go version to 1.N.P notation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/heathcliff26/promremote
 
-go 1.23
+go 1.23.0
 
 require (
 	github.com/golang/snappy v0.0.4


### PR DESCRIPTION
According to CodeQL:
As of Go 1.21, toolchain versions must use the 1.N.P syntax.