### PR TITLE
Makefile: Add fmt and validate commands

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,3 +22,9 @@ jobs:
 
   unit-tests:
     uses: heathcliff26/ci/.github/workflows/golang-unit-tests.yaml@main
+
+  validate:
+    uses: heathcliff26/ci/.github/workflows/golang-build.yaml@main
+    with:
+      cache: false
+      cmd: "make validate"

--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,18 @@ coverprofile:
 lint:
 	golangci-lint run -v
 
+fmt:
+	gofmt -s -w ./promremote
+
+validate:
+	hack/validate.sh
+
 .PHONY: \
 	default \
 	test \
 	update-deps \
 	coverprofile \
 	lint \
+	fmt \
+	validate \
 	$(NULL)

--- a/hack/validate.sh
+++ b/hack/validate.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+echo "Check if source code is formatted"
+make fmt
+rc=0
+git update-index --refresh && git diff-index --quiet HEAD -- || rc=1
+if [ $rc -ne 0 ]; then
+    echo "FATAL: Need to run \"make fmt\""
+    exit 1
+fi


### PR DESCRIPTION
Add a command to format the go code.
Add a command to validate that the workspace is clean.

Ensure code is always properly formatted by adding the validate step.