### PR TITLE
Accept all http 2xx codes

### DIFF
--- a/promremote/client.go
+++ b/promremote/client.go
@@ -103,7 +103,7 @@ func (c *Client) post(ts []prompb.TimeSeries) error {
 		return err
 	}
 	defer res.Body.Close()
-	if res.StatusCode != http.StatusOK {
+	if res.StatusCode < 200 || res.StatusCode > 299 {
 		return NewErrRemoteWriteFailed(res.StatusCode, req.Body)
 	}
 


### PR DESCRIPTION
Currently only 200 return codes are accepted, but prometheus might return 204.
Ensure all ok status returns are accepted.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>