### PR TITLE
Improve timings by using ticker instead of timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ slog.Info("Starting remote_write client")
 rwQuit := make(chan bool)
 rwClient.Run(interval, rwQuit)
 defer func() {
-    rwQuit <- true
     close(rwQuit)
 }()
 ```

--- a/promremote/client.go
+++ b/promremote/client.go
@@ -190,6 +190,9 @@ func (c *Client) collect() ([]prompb.TimeSeries, error) {
 // Does not block main thread execution
 func (c *Client) Run(interval time.Duration, quit chan bool) {
 	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		slog.Debug("Starting remote_write client")
 		for {
 			ts, err := c.collect()
 			if err != nil {
@@ -199,20 +202,14 @@ func (c *Client) Run(interval time.Duration, quit chan bool) {
 			if err != nil {
 				slog.Error("Failed to send metrics to remote endpoint", "err", err)
 			} else {
-				slog.Debug("Successfully send metrics via remote_write")
+				slog.Debug("Successfully sent metrics via remote_write")
 			}
+			select {
+			case <-ticker.C:
 
-			var elapsedTime time.Duration = 0
-			for elapsedTime < interval {
-				timer := time.NewTimer(1 * time.Second)
-				select {
-				case <-timer.C:
-					elapsedTime += time.Duration(1 * time.Second)
-				case <-quit:
-					timer.Stop()
-					slog.Info("Received stop signal, shutting down remote_write client")
-					return
-				}
+			case <-quit:
+				slog.Info("Received stop signal, shutting down remote_write client")
+				return
 			}
 		}
 	}()

--- a/promremote/client_test.go
+++ b/promremote/client_test.go
@@ -167,6 +167,8 @@ func TestCollect(t *testing.T) {
 }
 
 func TestRun(t *testing.T) {
+	assert := assert.New(t)
+
 	reg := prometheus.NewRegistry()
 	reg.MustRegister(collectors.NewBuildInfoCollector())
 
@@ -174,9 +176,6 @@ func TestRun(t *testing.T) {
 
 	var buf bytes.Buffer
 	log.SetOutput(&buf)
-	t.Cleanup(func() {
-		log.SetOutput(os.Stderr)
-	})
 
 	quit := make(chan bool)
 	c.Run(time.Second, quit)
@@ -184,6 +183,10 @@ func TestRun(t *testing.T) {
 	<-time.After(time.Second * 2)
 	quit <- true
 
+	log.SetOutput(os.Stderr)
+
 	output := buf.String()
-	assert.Contains(t, output, "ERROR Failed to send metrics to remote endpoint err=", "Should output error to log and not fail")
+	t.Log(output)
+	assert.Contains(output, "ERROR Failed to send metrics to remote endpoint err=", "Should output error to log and not fail")
+	assert.Contains(output, "INFO Received stop signal, shutting down remote_write client", "Should shutdown cleanly")
 }


### PR DESCRIPTION
Ensure writes are performed in even intervalls by using ticker.
Fix wrong handling of select for channels, causing unnecessary cpu load.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>